### PR TITLE
fix: propagate errors from evaluateDanglingItems (#49)

### DIFF
--- a/src/context.zig
+++ b/src/context.zig
@@ -275,7 +275,9 @@ pub fn TaskEngineContextWith(
         /// Re-evaluate dangling items (call after scene load).
         pub fn evaluateDanglingItems() void {
             if (task_engine) |eng| {
-                eng.evaluateDanglingItems();
+                eng.evaluateDanglingItems() catch |err| {
+                    std.log.err("[TaskEngineContext] evaluateDanglingItems failed: {}", .{err});
+                };
             }
         }
     };

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -117,7 +117,7 @@ pub fn Engine(
 
             // If an empty EIS was added, check if any dangling items can be delivered
             if (config.role == .eis and config.initial_item == null) {
-                self.evaluateDanglingItems();
+                try self.evaluateDanglingItems();
             }
         }
 
@@ -367,7 +367,7 @@ pub fn Engine(
         pub fn addDanglingItem(self: *Self, item_id: GameId, item_type: Item) !void {
             try self.dangling_items.put(item_id, item_type);
             // Evaluate if any idle worker can pick up this item
-            self.evaluateDanglingItems();
+            try self.evaluateDanglingItems();
         }
 
         /// Remove a dangling item (picked up or despawned)
@@ -412,9 +412,9 @@ pub fn Engine(
         }
 
         /// Evaluate dangling items and try to assign workers
-        pub fn evaluateDanglingItems(self: *Self) void {
+        pub fn evaluateDanglingItems(self: *Self) !void {
             // Get idle workers (we need to free this later)
-            const idle_workers = self.getIdleWorkers() catch return;
+            const idle_workers = try self.getIdleWorkers();
             defer self.allocator.free(idle_workers);
 
             if (idle_workers.len == 0) return;

--- a/src/handlers.zig
+++ b/src/handlers.zig
@@ -76,7 +76,9 @@ pub fn Handlers(
             worker.assigned_workstation = null;
 
             // First, try to assign worker to pick up dangling items (higher priority)
-            engine.evaluateDanglingItems();
+            engine.evaluateDanglingItems() catch |err| {
+                log.err("worker_available: evaluateDanglingItems failed: {}", .{err});
+            };
 
             // If worker is still idle, try to assign to a queued workstation
             if (worker.state == .Idle) {
@@ -377,7 +379,9 @@ pub fn Handlers(
                 worker.state = .Idle;
 
                 // First, check for remaining dangling items (higher priority)
-                engine.evaluateDanglingItems();
+                engine.evaluateDanglingItems() catch |err| {
+                    log.err("store_completed: evaluateDanglingItems failed: {}", .{err});
+                };
 
                 // Re-evaluate workstations (EIS now has item, may become Queued)
                 // Only assign to workstations if worker is still idle

--- a/src/root.zig
+++ b/src/root.zig
@@ -365,7 +365,9 @@ pub fn createEngineHooks(
             std.log.debug("[labelle-tasks] scene_load: {s} - re-evaluating dangling items", .{info.name});
 
             if (Context.getEngine()) |task_eng| {
-                task_eng.evaluateDanglingItems();
+                task_eng.evaluateDanglingItems() catch |err| {
+                    std.log.err("[labelle-tasks] evaluateDanglingItems failed: {}", .{err});
+                };
             }
         }
 


### PR DESCRIPTION
## Summary

Change `evaluateDanglingItems` from returning `void` to `!void`, properly propagating allocation errors from `getIdleWorkers` instead of silently discarding them.

## Changes

- **engine.zig**: `evaluateDanglingItems` returns `!void`; `addStorage` and `addDanglingItem` propagate with `try`
- **handlers.zig**: `handleWorkerAvailable` and `handleStoreCompleted` catch errors with `catch |err| log.err(...)`
- **context.zig** / **root.zig**: Wrappers catch and log errors from `evaluateDanglingItems`
- **test/engine_spec.zig**: 2 new tests using `std.testing.FailingAllocator` to verify error propagation

## Testing

All existing + new tests pass with `zig build test`.

Closes #49
