### PR TITLE
feat: use IntegerBitSet(16) for per-workstation storage filled status (#43)

### DIFF
--- a/src/engine.zig
+++ b/src/engine.zig
@@ -185,6 +185,10 @@ pub fn Engine(
                     const new_eis = try self.allocator.alloc(GameId, ws.eis.len + 1);
                     @memcpy(new_eis[0..ws.eis.len], ws.eis);
                     new_eis[ws.eis.len] = storage_id;
+                    // Initialize bit based on current storage state
+                    if (self.storages.get(storage_id)) |storage| {
+                        if (storage.has_item) ws.eis_filled.set(ws.eis.len);
+                    }
                     self.allocator.free(ws.eis);
                     ws.eis = new_eis;
                 },
@@ -192,6 +196,9 @@ pub fn Engine(
                     const new_iis = try self.allocator.alloc(GameId, ws.iis.len + 1);
                     @memcpy(new_iis[0..ws.iis.len], ws.iis);
                     new_iis[ws.iis.len] = storage_id;
+                    if (self.storages.get(storage_id)) |storage| {
+                        if (storage.has_item) ws.iis_filled.set(ws.iis.len);
+                    }
                     self.allocator.free(ws.iis);
                     ws.iis = new_iis;
                 },
@@ -199,6 +206,9 @@ pub fn Engine(
                     const new_ios = try self.allocator.alloc(GameId, ws.ios.len + 1);
                     @memcpy(new_ios[0..ws.ios.len], ws.ios);
                     new_ios[ws.ios.len] = storage_id;
+                    if (self.storages.get(storage_id)) |storage| {
+                        if (storage.has_item) ws.ios_filled.set(ws.ios.len);
+                    }
                     self.allocator.free(ws.ios);
                     ws.ios = new_ios;
                 },
@@ -206,6 +216,9 @@ pub fn Engine(
                     const new_eos = try self.allocator.alloc(GameId, ws.eos.len + 1);
                     @memcpy(new_eos[0..ws.eos.len], ws.eos);
                     new_eos[ws.eos.len] = storage_id;
+                    if (self.storages.get(storage_id)) |storage| {
+                        if (storage.has_item) ws.eos_filled.set(ws.eos.len);
+                    }
                     self.allocator.free(ws.eos);
                     ws.eos = new_eos;
                 },

--- a/src/state.zig
+++ b/src/state.zig
@@ -1,5 +1,6 @@
 //! Internal state structs for the task engine
 
+const std = @import("std");
 const types = @import("types.zig");
 
 const WorkerState = types.WorkerState;
@@ -40,10 +41,18 @@ pub fn WorkerData(comptime GameId: type) type {
     };
 }
 
+/// Maximum number of storages per role in a workstation.
+/// Covers up to 16 EIS, 16 IIS, 16 IOS, or 16 EOS per workstation.
+pub const MAX_STORAGE_SLOTS = 16;
+
 /// Internal workstation state
 pub fn WorkstationData(comptime GameId: type) type {
+    const BitSet = std.bit_set.IntegerBitSet(MAX_STORAGE_SLOTS);
+
     return struct {
         const Self = @This();
+
+        pub const FilledBitSet = BitSet;
 
         status: WorkstationStatus = .Blocked,
         assigned_worker: ?GameId = null,
@@ -57,12 +66,47 @@ pub fn WorkstationData(comptime GameId: type) type {
         ios: []const GameId,
         eos: []const GameId,
 
+        // Filled status bitsets (indexed by position in storage arrays)
+        // Kept in sync with StorageState.has_item for O(1) aggregate checks
+        eis_filled: BitSet = BitSet.initEmpty(),
+        iis_filled: BitSet = BitSet.initEmpty(),
+        ios_filled: BitSet = BitSet.initEmpty(),
+        eos_filled: BitSet = BitSet.initEmpty(),
+
         // Selected storages for current cycle
         selected_eis: ?GameId = null,
         selected_eos: ?GameId = null,
 
         pub fn isProducer(self: *const Self) bool {
             return self.eis.len == 0 and self.iis.len == 0;
+        }
+
+        /// Check if all IIS are filled
+        pub fn allIisFilled(self: *const Self) bool {
+            return self.iis_filled.count() == self.iis.len;
+        }
+
+        /// Check if all IOS are empty
+        pub fn allIosEmpty(self: *const Self) bool {
+            return self.ios_filled.count() == 0;
+        }
+
+        /// Check if all EIS have items
+        pub fn allEisFilled(self: *const Self) bool {
+            return self.eis_filled.count() == self.eis.len;
+        }
+
+        /// Check if at least one EOS has space
+        pub fn hasEosSpace(self: *const Self) bool {
+            return self.eos_filled.count() < self.eos.len;
+        }
+
+        /// Find the index of a storage ID within a slice
+        pub fn storageIndex(slice: []const GameId, storage_id: GameId) ?usize {
+            for (slice, 0..) |id, i| {
+                if (id == storage_id) return i;
+            }
+            return null;
         }
     };
 }


### PR DESCRIPTION
## Summary

Replace linear scans over storage arrays with O(1) bitset checks for workstation readiness evaluation. Adds `IntegerBitSet(16)` fields to `WorkstationData` for each storage category (EIS, IIS, IOS, EOS).

## Changes

- **state.zig**: Add `FilledBitSet` type alias and 4 bitset fields (`eis_filled`, `iis_filled`, `ios_filled`, `eos_filled`) to `WorkstationData`. Add helper methods: `allIisFilled()`, `allIosEmpty()`, `allEisFilled()`, `hasEosSpace()`, `storageIndex()`
- **helpers.zig**: Add `refreshFilledBits()` to sync bitsets from `StorageState.has_item`. Replace `canWorkstationOperate` body with bitset-based O(1) checks. Remove unused engine parameter
- **handlers.zig**: Update `handlePickupCompleted`, `handleWorkCompleted`, `handleStoreCompleted` to maintain bits on storage transfers
- **engine.zig**: Initialize bits in `attachStorageToWorkstation` based on current storage state

## Performance

Storage readiness checks go from O(n) linear scans to O(1) bitwise operations, where n is the number of storage slots per workstation.

## Testing

All existing tests pass with `zig build test`.

Closes #43
