### PR TITLE
refactor: simplify EnrichedPayload in createEngineHooks

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -260,7 +260,7 @@ pub fn bind(comptime Item: type, comptime EngineTypes: type) type {
 /// const GameHooks = struct {
 ///     pub fn store_started(payload: anytype) void {
 ///         const registry = payload.registry orelse return;
-///         const worker = engine.entityFromU64(payload.worker_id);
+///         const worker = engine.entityFromU64(payload.original.worker_id);
 ///         registry.set(worker, MovementTarget{ ... });
 ///     }
 /// };


### PR DESCRIPTION
## Summary
- Replace complex conditional void-typed field generation with a simple wrapper struct
- EnrichedPayload now stores `.original` (raw payload) + `.registry` + `.game`
- Eliminates ~10 lines of repetitive conditional field declarations

Closes #50
Part of #58