### PR TITLE
feat: add reverse index storage→workstations

### DIFF
--- a/src/engine.zig
+++ b/src/engine.zig
@@ -317,6 +317,10 @@ pub fn Engine(
             if (!gop.found_existing) {
                 gop.value_ptr.* = .{};
             }
+            // Prevent duplicate entries
+            for (gop.value_ptr.items) |existing_id| {
+                if (existing_id == workstation_id) return;
+            }
             gop.value_ptr.append(self.allocator, workstation_id) catch {
                 std.log.err("[tasks] addReverseIndexEntry: failed to append workstation {} for storage {}", .{ workstation_id, storage_id });
             };


### PR DESCRIPTION
## Summary
- Add `storage_to_workstations` HashMap to engine for O(1) lookup of affected workstations
- Add `reevaluateAffectedWorkstations(storage_id)` that only re-evaluates workstations using that storage
- `handleItemAdded`/`handleItemRemoved` use targeted re-evaluation instead of full scan
- Reverse index maintained in `addWorkstation`, `removeWorkstation`, `attachStorageToWorkstation`

Closes #52
Part of #58