### PR TITLE
refactor: replace global mutable state with instance fields in TaskEngineContextWith

### DIFF
--- a/src/context.zig
+++ b/src/context.zig
@@ -1,7 +1,7 @@
 //! TaskEngineContext - Helper to reduce game integration boilerplate
 //!
 //! Wraps the task engine with common setup patterns:
-//! - Global state management (engine, registry, game pointers)
+//! - Instance-based state management (engine, registry, game pointers)
 //! - Custom vtable with ensureContext callback
 //! - Init/deinit lifecycle
 //! - Movement queue for hook-triggered worker movements
@@ -22,7 +22,7 @@
 //!
 //! // In game init hook - uses default distance function:
 //! pub fn game_init(payload: engine.HookPayload) void {
-//!     Context.init(payload.game_init.allocator) catch return;
+//!     _ = Context.init(payload.game_init.allocator) catch return;
 //! }
 //!
 //! // In game deinit hook:
@@ -35,31 +35,13 @@ const std = @import("std");
 const ecs_bridge = @import("ecs_bridge.zig");
 const engine_mod = @import("engine.zig");
 
-// ============================================
-// Shared Global State (accessible from hooks without Context type)
-// ============================================
-// These are set by TaskEngineContext.ensureContext and can be accessed
-// by enriched hook payloads without knowing the specific Context type.
-
-var shared_registry: ?*anyopaque = null;
-var shared_game: ?*anyopaque = null;
-
-/// Get the shared registry pointer (for use by enriched hook payloads)
-pub fn getSharedRegistry(comptime RegistryType: type) ?*RegistryType {
-    const ptr = shared_registry orelse return null;
-    return @ptrCast(@alignCast(ptr));
-}
-
-/// Get the shared game pointer (for use by enriched hook payloads)
-pub fn getSharedGame(comptime GameType: type) ?*GameType {
-    const ptr = shared_game orelse return null;
-    return @ptrCast(@alignCast(ptr));
-}
-
 /// Context for managing task engine lifecycle and game integration (with injected engine types).
 /// This version accepts EngineTypes to avoid importing labelle-engine directly,
 /// which prevents module collision in WASM builds.
-/// Eliminates boilerplate for vtable wrapping, global state, and movement queuing.
+///
+/// State is stored in a heap-allocated instance. A single `active` pointer per
+/// comptime instantiation provides static access for hooks and convenience wrappers.
+/// Multiple instances can coexist for testing by creating instances without setting active.
 pub fn TaskEngineContextWith(
     comptime GameId: type,
     comptime Item: type,
@@ -84,17 +66,20 @@ pub fn TaskEngineContextWith(
         const entityFromU64 = EngineTypes.entityFromU64;
 
         // ============================================
-        // Global State
+        // Active instance pointer (single remaining global)
         // ============================================
 
-        var task_engine: ?*Engine = null;
-        var engine_allocator: ?std.mem.Allocator = null;
-        var game_registry: ?*anyopaque = null;
-        var game_ptr: ?*anyopaque = null;
-        var distance_fn: ?*const fn (GameId, GameId) ?f32 = null;
+        var active: ?*Self = null;
 
-        // Custom vtable with ensureContext
-        var custom_vtable: EcsInterface.VTable = undefined;
+        // ============================================
+        // Instance fields (previously module-level globals)
+        // ============================================
+
+        engine: *Engine,
+        allocator: std.mem.Allocator,
+        registry_ptr: ?*anyopaque,
+        game_ptr: ?*anyopaque,
+        vtable: EcsInterface.VTable,
 
         // ============================================
         // Lifecycle
@@ -103,36 +88,47 @@ pub fn TaskEngineContextWith(
         /// Initialize the task engine context with default distance function.
         /// Call this during game initialization (e.g., in game_init hook).
         /// Uses euclidean distance based on Position components by default.
-        pub fn init(allocator: std.mem.Allocator) !void {
-            if (task_engine != null) return;
-
-            engine_allocator = allocator;
-            distance_fn = defaultDistanceFn;
+        /// Returns the instance and sets it as the active context.
+        pub fn init(allocator: std.mem.Allocator) !*Self {
+            if (active != null) return error.AlreadyInitialized;
 
             const eng = try allocator.create(Engine);
+            errdefer {
+                eng.deinit();
+                allocator.destroy(eng);
+            }
             eng.* = Engine.init(allocator, .{}, defaultDistanceFn);
-            task_engine = eng;
+
+            const self = try allocator.create(Self);
+            self.* = Self{
+                .engine = eng,
+                .allocator = allocator,
+                .registry_ptr = null,
+                .game_ptr = null,
+                .vtable = undefined,
+            };
 
             // Set up ECS interface with ensureContext callback
             const engine_iface = eng.interface();
-            custom_vtable = engine_iface.vtable.*;
-            custom_vtable.ensureContext = ensureContext;
+            self.vtable = engine_iface.vtable.*;
+            self.vtable.ensureContext = ensureContext;
 
             EcsInterface.setActive(.{
                 .ptr = engine_iface.ptr,
-                .vtable = &custom_vtable,
+                .vtable = &self.vtable,
             });
 
+            active = self;
+
             std.log.info("[TaskEngineContext] Initialized", .{});
+            return self;
         }
 
         /// Set a custom distance function (overrides default).
         /// Call after init() if you need custom distance calculations.
         pub fn setDistanceFunction(func: *const fn (GameId, GameId) ?f32) void {
-            distance_fn = func;
-            if (task_engine) |eng| {
-                eng.setDistanceFunction(func);
-            }
+            const self = active orelse return;
+            self.engine.setDistanceFunction(func);
         }
 
         /// Default distance function using Position components.
@@ -154,34 +150,25 @@ pub fn TaskEngineContextWith(
         /// Deinitialize the task engine context.
         /// Call this during game cleanup (e.g., in game_deinit hook).
         pub fn deinit() void {
-            if (task_engine) |eng| {
-                EcsInterface.clearActive();
-                eng.deinit();
-                if (engine_allocator) |allocator| {
-                    allocator.destroy(eng);
-                }
-            }
-            task_engine = null;
-            engine_allocator = null;
-            game_registry = null;
-            game_ptr = null;
-            // Clear shared globals
-            shared_registry = null;
-            shared_game = null;
+            const self = active orelse return;
+            active = null;
+
+            EcsInterface.clearActive();
+            self.engine.deinit();
+            const alloc = self.allocator;
+            alloc.destroy(self.engine);
+            alloc.destroy(self);
             std.log.info("[TaskEngineContext] Deinitialized", .{});
         }
 
         /// ECS bridge callback - sets game/registry pointers on first component registration.
         fn ensureContext(game_ptr_raw: *anyopaque, registry_ptr_raw: *anyopaque) void {
-            if (game_registry == null) {
-                game_registry = registry_ptr_raw;
-                // Also set shared globals for hook payload enrichment
-                shared_registry = registry_ptr_raw;
+            const self = active orelse return;
+            if (self.registry_ptr == null) {
+                self.registry_ptr = registry_ptr_raw;
             }
-            if (game_ptr == null) {
-                game_ptr = game_ptr_raw;
-                // Also set shared globals for hook payload enrichment
-                shared_game = game_ptr_raw;
+            if (self.game_ptr == null) {
+                self.game_ptr = game_ptr_raw;
             }
         }
 
@@ -189,30 +176,40 @@ pub fn TaskEngineContextWith(
         // Accessors
         // ============================================
 
+        /// Get the active instance (if initialized).
+        pub fn getInstance() ?*Self {
+            return active;
+        }
+
         /// Get the task engine instance (if initialized).
         pub fn getEngine() ?*Engine {
-            return task_engine;
+            const self = active orelse return null;
+            return self.engine;
         }
 
         /// Get the game registry pointer (if set via ensureContext).
         pub fn getRegistryPtr() ?*anyopaque {
-            return game_registry;
+            const self = active orelse return null;
+            return self.registry_ptr;
         }
 
         /// Get the game pointer (if set via ensureContext).
         pub fn getGamePtr() ?*anyopaque {
-            return game_ptr;
+            const self = active orelse return null;
+            return self.game_ptr;
         }
 
         /// Get the registry cast to a specific type.
         pub fn getRegistry(comptime RegistryType: type) ?*RegistryType {
-            const ptr = game_registry orelse return null;
+            const self = active orelse return null;
+            const ptr = self.registry_ptr orelse return null;
             return @ptrCast(@alignCast(ptr));
         }
 
         /// Get the game cast to a specific type.
         pub fn getGame(comptime GameType: type) ?*GameType {
-            const ptr = game_ptr orelse return null;
+            const self = active orelse return null;
+            const ptr = self.game_ptr orelse return null;
             return @ptrCast(@alignCast(ptr));
         }
 
@@ -222,49 +219,49 @@ pub fn TaskEngineContextWith(
 
         /// Notify that a pickup was completed.
         pub fn pickupCompleted(worker_id: GameId) bool {
-            const eng = task_engine orelse return false;
-            return eng.pickupCompleted(worker_id);
+            const self = active orelse return false;
+            return self.engine.pickupCompleted(worker_id);
         }
 
         /// Notify that a store was completed.
         pub fn storeCompleted(worker_id: GameId) bool {
-            const eng = task_engine orelse return false;
-            return eng.storeCompleted(worker_id);
+            const self = active orelse return false;
+            return self.engine.storeCompleted(worker_id);
         }
 
         /// Notify that work was completed at a workstation.
         pub fn workCompleted(workstation_id: GameId) bool {
-            const eng = task_engine orelse return false;
-            return eng.workCompleted(workstation_id);
+            const self = active orelse return false;
+            return self.engine.workCompleted(workstation_id);
         }
 
         /// Notify that an item was added to a storage.
         pub fn itemAdded(storage_id: GameId, item: Item) bool {
-            const eng = task_engine orelse return false;
-            return eng.itemAdded(storage_id, item);
+            const self = active orelse return false;
+            return self.engine.itemAdded(storage_id, item);
         }
 
         /// Notify that an item was removed from a storage.
         pub fn itemRemoved(storage_id: GameId) bool {
-            const eng = task_engine orelse return false;
-            return eng.itemRemoved(storage_id);
+            const self = active orelse return false;
+            return self.engine.itemRemoved(storage_id);
         }
 
         /// Notify that a worker became available.
         pub fn workerAvailable(worker_id: GameId) bool {
-            const eng = task_engine orelse return false;
-            return eng.workerAvailable(worker_id);
+            const self = active orelse return false;
+            return self.engine.workerAvailable(worker_id);
         }
 
         /// Generic handler for when a worker arrives at its destination.
         /// Automatically determines the correct completion based on current step.
         /// Returns true if an event was handled.
         pub fn workerArrived(worker_id: GameId) bool {
-            const eng = task_engine orelse return false;
-            const step = eng.getWorkerCurrentStep(worker_id) orelse return false;
+            const self = active orelse return false;
+            const step = self.engine.getWorkerCurrentStep(worker_id) orelse return false;
             return switch (step) {
-                .Pickup => eng.pickupCompleted(worker_id),
-                .Store => eng.storeCompleted(worker_id),
+                .Pickup => self.engine.pickupCompleted(worker_id),
+                .Store => self.engine.storeCompleted(worker_id),
                 .Process => false, // Process uses workCompleted when timer finishes
             };
         }
@@ -278,9 +275,8 @@ pub fn TaskEngineContextWith(
 
         /// Re-evaluate dangling items (call after scene load).
         pub fn evaluateDanglingItems() void {
-            if (task_engine) |eng| {
-                eng.evaluateDanglingItems();
-            }
+            const self = active orelse return;
+            self.engine.evaluateDanglingItems();
         }
     };
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -281,7 +281,7 @@ pub fn createEngineHooks(
     const Game = EngineTypes.Game;
 
     // Create a wrapper that enriches payloads with registry and game.
-    // Uses shared global storage from context module (set by ensureContext).
+    // Uses active context instance for registry/game access.
     const WrappedHooks = struct {
         /// Simple enriched payload wrapper: stores original payload + context.
         fn EnrichedPayload(comptime Original: type) type {
@@ -296,8 +296,8 @@ pub fn createEngineHooks(
                 fn create(orig: Original) @This() {
                     return .{
                         .original = orig,
-                        .registry = context_mod.getSharedRegistry(Registry),
-                        .game = context_mod.getSharedGame(Game),
+                        .registry = Ctx.getRegistry(Registry),
+                        .game = Ctx.getGame(Game),
                     };
                 }
             };
@@ -342,7 +342,7 @@ pub fn createEngineHooks(
         pub fn game_init(payload: EngineTypes.HookPayload) void {
             const info = payload.game_init;
 
-            Context.init(info.allocator) catch |err| {
+            _ = Context.init(info.allocator) catch |err| {
                 std.log.err("[labelle-tasks] Failed to initialize task engine: {}", .{err});
                 return;
             };


### PR DESCRIPTION
## Summary
- Move module-level `shared_registry`/`shared_game` globals and comptime struct-level `var` declarations into heap-allocated instance fields
- Single `var active: ?*Self = null` per comptime instantiation provides static access for hooks
- `init()` returns `*Self` (instance pointer) and sets `active`
- All convenience methods use `active` internally for backward compatibility
- Enables multiple contexts for testing without shared state

Closes #45
Part of #58