### PR TITLE
feat: migrate to Zig 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run tests
         working-directory: labelle-tasks
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build library
         working-directory: labelle-tasks

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/refs/heads/main.tar.gz",
-            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
+            .url = "git+https://github.com/apotema/zspec.git?ref=feat/zig-0.16-migration#42e1e69e31a6971c93e6807d29eabe30d9f46bd6",
+            .hash = "zspec-0.8.0-jaKLbe3SAwDRIFxFJbSQvz_lr9Xn-trRT9KR16I8C5_P",
         },
         // labelle-engine dependency removed - types now injected via EngineTypes parameter
         // to prevent WASM module collision (issue #38)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zspec = .{
-            .url = "git+https://github.com/apotema/zspec.git?ref=feat/zig-0.16-migration#42e1e69e31a6971c93e6807d29eabe30d9f46bd6",
-            .hash = "zspec-0.8.0-jaKLbe3SAwDRIFxFJbSQvz_lr9Xn-trRT9KR16I8C5_P",
+            .url = "https://github.com/apotema/zspec/archive/v0.9.0.tar.gz",
+            .hash = "zspec-0.9.0-jaKLba73AwB5EK3YFyhpQ4roFBA_hhGbVvjSjur3KxZz",
         },
         // labelle-engine dependency removed - types now injected via EngineTypes parameter
         // to prevent WASM module collision (issue #38)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/v0.9.0.tar.gz",
-            .hash = "zspec-0.9.0-jaKLba73AwB5EK3YFyhpQ4roFBA_hhGbVvjSjur3KxZz",
+            .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
+            .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
         },
         // labelle-engine dependency removed - types now injected via EngineTypes parameter
         // to prevent WASM module collision (issue #38)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,11 +2,11 @@
     .fingerprint = 0x9883692330f70d05,
     .name = .labelle_tasks,
     .version = "0.21.0",
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zspec = .{
             .url = "https://github.com/apotema/zspec/archive/refs/heads/main.tar.gz",
-            .hash = "zspec-0.6.0-jaKLbU5DAwAYa0jR0cnFGuIbSrxD6ojh-oyXj9ooyb3V",
+            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
         },
         // labelle-engine dependency removed - types now injected via EngineTypes parameter
         // to prevent WASM module collision (issue #38)

--- a/src/dangling.zig
+++ b/src/dangling.zig
@@ -65,7 +65,7 @@ pub fn DanglingManager(
 
         /// Get list of idle workers (allocated, caller must free)
         pub fn getIdleWorkers(engine: *EngineType) ![]GameId {
-            var list: std.ArrayListUnmanaged(GameId) = .{};
+            var list: std.ArrayListUnmanaged(GameId) = .empty;
             errdefer list.deinit(engine.allocator);
 
             var iter = engine.workers.iterator();
@@ -85,7 +85,7 @@ pub fn DanglingManager(
             if (engine.idle_workers_set.count() == 0) return;
 
             // Snapshot idle workers into local buffer (reentrancy-safe pattern)
-            var idle_buf: std.ArrayListUnmanaged(GameId) = .{};
+            var idle_buf: std.ArrayListUnmanaged(GameId) = .empty;
             defer idle_buf.deinit(engine.allocator);
             idle_buf.ensureTotalCapacity(engine.allocator, engine.idle_workers_set.count()) catch return;
             var idle_iter = engine.idle_workers_set.keyIterator();
@@ -99,7 +99,7 @@ pub fn DanglingManager(
             // Snapshot dangling items to avoid iterator invalidation if hooks
             // modify dangling_items during dispatch (e.g., addDanglingItem/removeDanglingItem)
             const DanglingEntry = struct { id: GameId, item_type: Item };
-            var dangling_snapshot: std.ArrayListUnmanaged(DanglingEntry) = .{};
+            var dangling_snapshot: std.ArrayListUnmanaged(DanglingEntry) = .empty;
             defer dangling_snapshot.deinit(engine.allocator);
             dangling_snapshot.ensureTotalCapacity(engine.allocator, engine.dangling_items.count()) catch return;
             var snap_iter = engine.dangling_items.iterator();

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -368,7 +368,7 @@ pub fn Engine(
                 return;
             };
             if (!gop.found_existing) {
-                gop.value_ptr.* = .{};
+                gop.value_ptr.* = .empty;
             }
             for (gop.value_ptr.items) |existing_id| {
                 if (existing_id == workstation_id) return;

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -328,7 +328,7 @@ pub fn Engine(
             if (self.storage_to_workstations.get(storage_id)) |ws_ids| {
                 // Snapshot workstation IDs to avoid dangling pointer if the list
                 // is freed by a reentrant removeStorage call during evaluation
-                var snapshot: std.ArrayListUnmanaged(GameId) = .{};
+                var snapshot: std.ArrayListUnmanaged(GameId) = .empty;
                 defer snapshot.deinit(self.allocator);
                 snapshot.appendSlice(self.allocator, ws_ids.items) catch {
                     // On OOM, skip evaluation but still set dirty flag
@@ -663,7 +663,7 @@ pub fn Engine(
             if (self.idle_workers_set.count() == 0) return;
 
             // Snapshot idle workers (reentrancy-safe)
-            var idle_buf: std.ArrayListUnmanaged(GameId) = .{};
+            var idle_buf: std.ArrayListUnmanaged(GameId) = .empty;
             defer idle_buf.deinit(self.allocator);
             idle_buf.ensureTotalCapacity(self.allocator, self.idle_workers_set.count()) catch return;
             var idle_iter = self.idle_workers_set.keyIterator();
@@ -686,7 +686,7 @@ pub fn Engine(
 
             // Snapshot EOS storages with items (O(S) single pass)
             const EosEntry = struct { id: GameId, item_type: Item };
-            var eos_snapshot: std.ArrayListUnmanaged(EosEntry) = .{};
+            var eos_snapshot: std.ArrayListUnmanaged(EosEntry) = .empty;
             defer eos_snapshot.deinit(self.allocator);
 
             var storage_iter = self.storages.iterator();

--- a/src/helpers.zig
+++ b/src/helpers.zig
@@ -126,9 +126,9 @@ pub fn Helpers(
 
             // Snapshot into local buffers to avoid reentrancy issues
             // (assignWorkerToWorkstation dispatches hooks which could trigger tryAssignWorkers again)
-            var idle_scratch: std.ArrayListUnmanaged(GameId) = .{};
+            var idle_scratch: std.ArrayListUnmanaged(GameId) = .empty;
             defer idle_scratch.deinit(engine.allocator);
-            var queued_scratch: std.ArrayListUnmanaged(GameId) = .{};
+            var queued_scratch: std.ArrayListUnmanaged(GameId) = .empty;
             defer queued_scratch.deinit(engine.allocator);
 
             idle_scratch.ensureTotalCapacity(engine.allocator, engine.idle_workers_set.count()) catch return;

--- a/src/hooks.zig
+++ b/src/hooks.zig
@@ -286,7 +286,7 @@ pub fn RecordingHooks(comptime GameId: type, comptime Item: type) type {
         }
 
         /// Assert the next event matches the expected tag (O(1), non-destructive)
-        pub fn expectNext(self: *Self, comptime expected_tag: std.meta.Tag(Payload)) !std.meta.TagPayload(Payload, expected_tag) {
+        pub fn expectNext(self: *Self, comptime expected_tag: std.meta.Tag(Payload)) !@FieldType(Payload, @tagName(expected_tag)) {
             if (self.next_idx >= self.events.items.len) {
                 std.debug.print("Expected {s} event but no more events recorded\n", .{@tagName(expected_tag)});
                 return error.NoEventsRecorded;

--- a/src/hooks.zig
+++ b/src/hooks.zig
@@ -253,7 +253,7 @@ pub fn RecordingHooks(comptime GameId: type, comptime Item: type) type {
     return struct {
         const Self = @This();
 
-        events: std.ArrayListUnmanaged(Payload) = .{},
+        events: std.ArrayListUnmanaged(Payload) = .empty,
         allocator: ?std.mem.Allocator = null,
         next_idx: usize = 0,
 

--- a/src/query.zig
+++ b/src/query.zig
@@ -169,7 +169,7 @@ pub fn Query(
             });
 
             // Storages (sorted by ID for deterministic output)
-            var s_keys: std.ArrayListUnmanaged(GameId) = .{};
+            var s_keys: std.ArrayListUnmanaged(GameId) = .empty;
             defer s_keys.deinit(engine.allocator);
             var s_iter = engine.storages.keyIterator();
             while (s_iter.next()) |key| try s_keys.append(engine.allocator, key.*);
@@ -187,7 +187,7 @@ pub fn Query(
             }
 
             // Workers (sorted by ID)
-            var w_keys: std.ArrayListUnmanaged(GameId) = .{};
+            var w_keys: std.ArrayListUnmanaged(GameId) = .empty;
             defer w_keys.deinit(engine.allocator);
             var w_iter = engine.workers.keyIterator();
             while (w_iter.next()) |key| try w_keys.append(engine.allocator, key.*);
@@ -203,7 +203,7 @@ pub fn Query(
             }
 
             // Workstations (sorted by ID)
-            var ws_keys: std.ArrayListUnmanaged(GameId) = .{};
+            var ws_keys: std.ArrayListUnmanaged(GameId) = .empty;
             defer ws_keys.deinit(engine.allocator);
             var ws_iter = engine.workstations.keyIterator();
             while (ws_iter.next()) |key| try ws_keys.append(engine.allocator, key.*);
@@ -225,7 +225,7 @@ pub fn Query(
 
             // Dangling items (sorted by ID)
             if (engine.dangling_items.count() > 0) {
-                var d_keys: std.ArrayListUnmanaged(GameId) = .{};
+                var d_keys: std.ArrayListUnmanaged(GameId) = .empty;
                 defer d_keys.deinit(engine.allocator);
                 var d_iter = engine.dangling_items.keyIterator();
                 while (d_iter.next()) |key| try d_keys.append(engine.allocator, key.*);

--- a/src/registration.zig
+++ b/src/registration.zig
@@ -59,19 +59,19 @@ pub fn Registration(
 
         /// Register a workstation with the engine
         pub fn addWorkstation(engine: *EngineType, workstation_id: GameId, config: WorkstationConfig) !void {
-            var eis = std.ArrayListUnmanaged(GameId){};
+            var eis: std.ArrayListUnmanaged(GameId) = .empty;
             errdefer eis.deinit(engine.allocator);
             try eis.appendSlice(engine.allocator, config.eis);
 
-            var iis = std.ArrayListUnmanaged(GameId){};
+            var iis: std.ArrayListUnmanaged(GameId) = .empty;
             errdefer iis.deinit(engine.allocator);
             try iis.appendSlice(engine.allocator, config.iis);
 
-            var ios = std.ArrayListUnmanaged(GameId){};
+            var ios: std.ArrayListUnmanaged(GameId) = .empty;
             errdefer ios.deinit(engine.allocator);
             try ios.appendSlice(engine.allocator, config.ios);
 
-            var eos = std.ArrayListUnmanaged(GameId){};
+            var eos: std.ArrayListUnmanaged(GameId) = .empty;
             errdefer eos.deinit(engine.allocator);
             try eos.appendSlice(engine.allocator, config.eos);
 

--- a/src/state.zig
+++ b/src/state.zig
@@ -62,10 +62,10 @@ pub fn WorkstationData(comptime GameId: type) type {
         priority: Priority = .Normal,
 
         // Storage references (by GameId) - dynamically growable lists
-        eis: std.ArrayListUnmanaged(GameId) = .{},
-        iis: std.ArrayListUnmanaged(GameId) = .{},
-        ios: std.ArrayListUnmanaged(GameId) = .{},
-        eos: std.ArrayListUnmanaged(GameId) = .{},
+        eis: std.ArrayListUnmanaged(GameId) = .empty,
+        iis: std.ArrayListUnmanaged(GameId) = .empty,
+        ios: std.ArrayListUnmanaged(GameId) = .empty,
+        eos: std.ArrayListUnmanaged(GameId) = .empty,
 
         // Selected storages for current cycle
         selected_eis: ?GameId = null,

--- a/test/engine_spec.zig
+++ b/test/engine_spec.zig
@@ -1561,10 +1561,10 @@ pub const Engine = zspec.describe("Engine", struct {
             try engine.addWorker(10);
 
             var buf: [4096]u8 = undefined;
-            var stream = std.io.fixedBufferStream(&buf);
-            try engine.dumpState(stream.writer());
+            var writer = std.Io.Writer.fixed(&buf);
+            try engine.dumpState(&writer);
 
-            const output = stream.getWritten();
+            const output = writer.buffered();
             // Verify it contains key information
             try std.testing.expect(std.mem.containsAtLeast(u8, output, 1, "Task Engine State"));
             try std.testing.expect(std.mem.containsAtLeast(u8, output, 1, "Storages: 4"));


### PR DESCRIPTION
## Summary
- Bumps `minimum_zig_version` to 0.16.0
- Bumps zspec to apotema/zspec 0.16 branch
- `ArrayListUnmanaged(T) = .{}` → `.empty` (7 source files + query.zig sites)
- `std.meta.TagPayload(Payload, tag)` → `@FieldType(Payload, @tagName(tag))` (hooks.zig)
- `std.io.fixedBufferStream` → `std.Io.Writer.fixed` (engine_spec.zig)

## Status
- `zig build -Dexamples=false`: ✅ PASS
- `zig build test -Dexamples=false`: ✅ PASS
- Default `zig build` (with examples) still fails on `GeneralPurposeAllocator` in `usage/kitchen-sim/main.zig` — out of scope per project convention.